### PR TITLE
add global variable for css media query

### DIFF
--- a/styles/mediaQueries.ts
+++ b/styles/mediaQueries.ts
@@ -1,0 +1,11 @@
+export const breakpoints = {
+	tablet: 992
+};
+
+export const size = {
+	tablet: `${breakpoints.tablet}px`
+};
+
+export const device = {
+	tablet: `(max-width: ${size.tablet})`
+};


### PR DESCRIPTION
Consider adding global variable to be used in css media queries throughout the application.

I used one of the breakpoints, implemented in Bootstrap - 992px, and named it tablet. 
I used max-width media query as to go in the direction desktop-first  -> tablet second. 

Feel free to make your suggestions and improvements.

use example:
@media ${device.tablet} {
      //styles for tablet screen
    }

[Trello task - add constant media query to use in development](https://trello.com/c/t7YzvFQt/65-add-constant-media-query-to-use-in-development)